### PR TITLE
Bugs Fixed for Some ISA Tests (Along with Feedbacks)

### DIFF
--- a/configure
+++ b/configure
@@ -610,6 +610,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -680,6 +681,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -932,6 +934,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1069,7 +1080,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1222,6 +1233,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/isa/Makefile
+++ b/isa/Makefile
@@ -35,7 +35,7 @@ default: all
 # Build rules
 #--------------------------------------------------------------------
 
-RISCV_PREFIX ?= riscv$(XLEN)-rivai-elf-
+RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
 RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data

--- a/isa/Makefile
+++ b/isa/Makefile
@@ -35,7 +35,7 @@ default: all
 # Build rules
 #--------------------------------------------------------------------
 
-RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
+RISCV_PREFIX ?= riscv$(XLEN)-rivai-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
 RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data

--- a/isa/macros/scalar/test_macros_vector.h
+++ b/isa/macros/scalar/test_macros_vector.h
@@ -101,6 +101,7 @@ test_ ## testnum: \
 
 #define TEST_CASE_MASK( testnum, testreg, correctval, code... ) \
 test_ ## testnum: \
+    vmv.v.x testreg, x0; \
     code; \
     li x7, correctval; \
     li TESTNUM, testnum; \
@@ -109,6 +110,7 @@ test_ ## testnum: \
 
 #define TEST_CASE_MASK_4VL( testnum, testreg, correctval, code... ) \
 test_ ## testnum: \
+    vmv.v.x testreg, x0; \
     code; \
     li x7, correctval; \
     li TESTNUM, testnum; \
@@ -214,6 +216,10 @@ test_ ## testnum: \
 # For simplicity, all vlseg/vsseg test use 3 fields
 #define TEST_CASE_VLSEG3( testnum, testreg, eew, correctval1, correctval2, correctval3, code... ) \
 test_ ## testnum: \
+    li x7, 0; \
+    vmv.v.x v14, x7; \
+    vmv.v.x v15, x7; \
+    vmv.v.x v16, x7; \
     code; \
     li x7, MASK_EEW(correctval1, eew); \
     li x8, MASK_EEW(correctval2, eew); \
@@ -646,6 +652,19 @@ test_ ## testnum: \
     inst v14, v1, v2; \
   )
 
+#define TEST_W_WV_RED_OP_WITH_INIT( testnum, inst, result, val1, val2 ) \
+  TEST_CASE_W( testnum, v14, result, \
+    li x7, 0; \
+    VSET_DOUBLE_VSEW \
+    vmv.v.x v14, x7; \
+    li x7, MASK_DOUBLE_VSEW(val2); \
+    vmv.v.x v2, x7; \
+    VSET_VSEW \
+    li x7, MASK_VSEW(val1); \
+    vmv.v.x v1, x7; \
+    inst v14, v1, v2; \
+  )
+
 #define TEST_W_VX_OP( testnum, inst, result, val1, val2 ) \
   TEST_CASE_W( testnum, v14, result, \
     li x7, MASK_VSEW(val1); \
@@ -687,7 +706,9 @@ test_ ## testnum: \
 #define TEST_N_VV_OP( testnum, inst, result, val2, val1 ) \
   TEST_CASE( testnum, v14, MASK_VSEW(result), \
     li x7, SEXT_DOUBLE_VSEW(val2); \
+    VSET_DOUBLE_VSEW \
     vmv.v.x v2, x7; \
+    VSET_VSEW \
     li x7, MASK_VSEW(val1); \
     vmv.v.x v1, x7; \
     inst v14, v2, v1; \
@@ -696,7 +717,9 @@ test_ ## testnum: \
 #define TEST_N_VX_OP( testnum, inst, result, val2, val1 ) \
   TEST_CASE( testnum, v14, MASK_VSEW(result), \
     li x7, SEXT_DOUBLE_VSEW(val2); \
+    VSET_DOUBLE_VSEW \
     vmv.v.x v2, x7; \
+    VSET_VSEW \
     li x1, MASK_VSEW(val1); \
     inst v14, v2, x1; \
   )
@@ -704,7 +727,9 @@ test_ ## testnum: \
 #define TEST_N_VI_OP( testnum, inst, result, val2, val1 ) \
   TEST_CASE( testnum, v14, MASK_VSEW(result), \
     li x7, SEXT_DOUBLE_VSEW(val2); \
+    VSET_DOUBLE_VSEW \
     vmv.v.x v2, x7; \
+    VSET_VSEW \
     inst v14, v2, SEXT_IMM(val1); \
   )
 
@@ -1012,6 +1037,8 @@ test_ ## testnum: \
 
 #define TEST_VLSSEG1_OP( testnum, inst, eew, result, stride, base ) \
   TEST_CASE( testnum, v14, result,  \
+    li x7, 0; \
+    vmv.v.x v14, x7; \
     la  x1, base; \
     li  x2, stride; \
     inst v14, (x1), x2; \

--- a/isa/macros/scalar/test_macros_vector.h
+++ b/isa/macros/scalar/test_macros_vector.h
@@ -70,6 +70,25 @@ test_ ## testnum: \
     VMVXS_AND_MASK_VSEW( x14, testreg ) \
     bne x14, x7, fail;
 
+#define TEST_CASE_MEM( testnum, testreg, correctval, eewmem, code... ) \
+test_ ## testnum: \
+    code; \
+    li x7, MASK_VSEW(correctval); \
+    li TESTNUM, testnum; \
+    VMVXS_AND_MASK_EEW( x14, testreg, eewmem ) \
+    bne x14, x7, fail;
+
+#define TEST_CASE_FP_FLAG( testnum, testreg, correctval, flags, code... ) \
+test_ ## testnum: \
+    code; \
+    li x7, MASK_VSEW(correctval); \
+    li TESTNUM, testnum; \
+    fsflags a1, x0; \
+    li a2, flags; \
+    bne a1, a2, fail; \
+    VMVXS_AND_MASK_VSEW( x14, testreg ) \
+    bne x14, x7, fail;
+
 #define TEST_CASE_W( testnum, testreg, correctval, code... ) \
 test_ ## testnum: \
     code; \
@@ -841,15 +860,11 @@ test_ ## testnum: \
     inst v14, v2; \
   )
 
-# TEST_CASE wont check flags so check here
 #define TEST_FP_HEX_1OPERAND_OP( testnum, inst, flags, result, val ) \
-  TEST_CASE( testnum, v14, result, \
+  TEST_CASE_FP_FLAG( testnum, v14, result, flags, \
     li x7, MASK_VSEW(val); \
     vmv.v.x v1, x7; \
     inst v14, v1; \
-    fsflags a1, x0; \
-    li a2, flags; \
-    bne a1, a2, fail; \
   )
 
 #define TEST_VVM_OP( testnum, inst, result, val1, val2 ) \
@@ -971,7 +986,7 @@ test_ ## testnum: \
   )
 
 #define TEST_VLSEG1_OP( testnum, inst, eew, result, base ) \
-  TEST_CASE( testnum, v14, result,  \
+  TEST_CASE_MEM( testnum, v14, result, eew,  \
     la  x1, base; \
     inst v14, (x1); \
   )
@@ -1035,7 +1050,7 @@ test_ ## testnum: \
 
 
 #define TEST_VSSEG1_OP( testnum, load_inst, store_inst, eew, result, base ) \
-  TEST_CASE( testnum, v14, result,  \
+  TEST_CASE_MEM( testnum, v14, result, eew,  \
     la  x1, base; \
     li x7, MASK_EEW(result, eew); \
     vsetivli x31, 1, MK_EEW(eew), tu, mu; \
@@ -1062,7 +1077,7 @@ test_ ## testnum: \
   )
 
 #define TEST_VSSSEG1_OP( testnum, load_inst, store_inst, eew, result, stride, base ) \
-  TEST_CASE( testnum, v14, result,  \
+  TEST_CASE_MEM( testnum, v14, result, eew,  \
     la  x1, base; \
     li  x2, stride; \
     li x7, MASK_EEW(result, eew); \
@@ -1100,7 +1115,7 @@ test_ ## testnum: \
   )
 
 #define TEST_VSSE_OP( testnum, load_inst, store_inst, eew, result, stride, base ) \
-  TEST_CASE( testnum, v14, result, \
+  TEST_CASE_MEM( testnum, v14, result, eew, \
     la  x1, base; \
     li  x2, stride; \
     li  x3, result; \
@@ -1112,7 +1127,7 @@ test_ ## testnum: \
   )
 
 #define TEST_VSE_OP( testnum, load_inst, store_inst, eew, result, base ) \
-  TEST_CASE( testnum, v14, result, \
+  TEST_CASE_MEM( testnum, v14, result, eew, \
     la  x1, base; \
     li  x3, result; \
     vsetivli x31, 1, MK_EEW(eew), tu, mu; \

--- a/isa/rv64uv/vsra.S
+++ b/isa/rv64uv/vsra.S
@@ -79,15 +79,17 @@ RVTEST_VSET
 
 #if __riscv_vsew <= 32
 
+  # Note: Need to put some meaningful data in the upper 32 bits and see if vnsra preserve them, same for vnsrl
+
   #-------------------------------------------------------------
   # WV tests
   #-------------------------------------------------------------
 
   TEST_N_VV_OP( 44, vnsra.wv, 0xffffffff80000000, 0xffffffff80000000, 0  );
-  TEST_N_VV_OP( 45, vnsra.wv, 0xffffffff40000000, 0xffffffff80000000, 1  );
-  TEST_N_VV_OP( 46, vnsra.wv, 0xffffffff01000000, 0xffffffff80000000, 7  );
-  TEST_N_VV_OP( 47, vnsra.wv, 0xffffffff00020000, 0xffffffff80000000, 14 );
-  TEST_N_VV_OP( 48, vnsra.wv, 0xffffffff00000001, 0xffffffff80000001, 31 );
+  TEST_N_VV_OP( 45, vnsra.wv, 0xffffffffc0000000, 0xffffffff80000000, 1  );
+  TEST_N_VV_OP( 46, vnsra.wv, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_N_VV_OP( 47, vnsra.wv, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_N_VV_OP( 48, vnsra.wv, 0xffffffffffffffff, 0xffffffff80000001, 31 );
 
   TEST_N_VV_OP( 49, vnsra.wv, 0x000000007fffffff, 0x000000007fffffff, 0  );
   TEST_N_VV_OP( 50, vnsra.wv, 0x000000003fffffff, 0x000000007fffffff, 1  );
@@ -96,20 +98,20 @@ RVTEST_VSET
   TEST_N_VV_OP( 53, vnsra.wv, 0x0000000000000000, 0x000000007fffffff, 31 );
 
   TEST_N_VV_OP( 54, vnsra.wv, 0xffffffff81818181, 0xffffffff81818181, 0  );
-  TEST_N_VV_OP( 55, vnsra.wv, 0xffffffff40c0c0c0, 0xffffffff81818181, 1  );
-  TEST_N_VV_OP( 56, vnsra.wv, 0xffffffff01030303, 0xffffffff81818181, 7  );
-  TEST_N_VV_OP( 57, vnsra.wv, 0xffffffff00020606, 0xffffffff81818181, 14 );
-  TEST_N_VV_OP( 58, vnsra.wv, 0xffffffff00000001, 0xffffffff81818181, 31 );
+  TEST_N_VV_OP( 55, vnsra.wv, 0xffffffffc0c0c0c0, 0xffffffff81818181, 1  );
+  TEST_N_VV_OP( 56, vnsra.wv, 0xffffffffff030303, 0xffffffff81818181, 7  );
+  TEST_N_VV_OP( 57, vnsra.wv, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
+  TEST_N_VV_OP( 58, vnsra.wv, 0xffffffffffffffff, 0xffffffff81818181, 31 );
 
   #-----------------------------------------------------------
   # WX tests
   #-----------------------------------------------------------
 
   TEST_N_VX_OP( 59, vnsra.wx, 0xffffffff80000000, 0xffffffff80000000, 0  );
-  TEST_N_VX_OP( 60, vnsra.wx, 0xffffffff40000000, 0xffffffff80000000, 1  );
-  TEST_N_VX_OP( 61, vnsra.wx, 0xffffffff01000000, 0xffffffff80000000, 7  );
-  TEST_N_VX_OP( 62, vnsra.wx, 0xffffffff00020000, 0xffffffff80000000, 14 );
-  TEST_N_VX_OP( 63, vnsra.wx, 0xffffffff00000001, 0xffffffff80000001, 31 );
+  TEST_N_VX_OP( 60, vnsra.wx, 0xffffffffc0000000, 0xffffffff80000000, 1  );
+  TEST_N_VX_OP( 61, vnsra.wx, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_N_VX_OP( 62, vnsra.wx, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
+  TEST_N_VX_OP( 63, vnsra.wx, 0xffffffffffffffff, 0xffffffff80000001, 31 );
 	
   TEST_N_VX_OP( 64, vnsra.wx, 0x000000007fffffff, 0x000000007fffffff, 0  );
   TEST_N_VX_OP( 65, vnsra.wx, 0x000000003fffffff, 0x000000007fffffff, 1  );
@@ -118,19 +120,19 @@ RVTEST_VSET
   TEST_N_VX_OP( 68, vnsra.wx, 0x0000000000000000, 0x000000007fffffff, 31 );
 	
   TEST_N_VX_OP( 69, vnsra.wx, 0xffffffff81818181, 0xffffffff81818181, 0  );
-  TEST_N_VX_OP( 70, vnsra.wx, 0xffffffff40c0c0c0, 0xffffffff81818181, 1  );
-  TEST_N_VX_OP( 71, vnsra.wx, 0xffffffff01030303, 0xffffffff81818181, 7  );
-  TEST_N_VX_OP( 72, vnsra.wx, 0xffffffff00020606, 0xffffffff81818181, 14 );
-  TEST_N_VX_OP( 73, vnsra.wx, 0xffffffff00000001, 0xffffffff81818181, 31 );
+  TEST_N_VX_OP( 70, vnsra.wx, 0xffffffffc0c0c0c0, 0xffffffff81818181, 1  );
+  TEST_N_VX_OP( 71, vnsra.wx, 0xffffffffff030303, 0xffffffff81818181, 7  );
+  TEST_N_VX_OP( 72, vnsra.wx, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
+  TEST_N_VX_OP( 73, vnsra.wx, 0xffffffffffffffff, 0xffffffff81818181, 31 );
 
   #-----------------------------------------------------------
   # WI tests
   #-----------------------------------------------------------
 
   TEST_N_VI_OP( 74, vnsra.wi, 0xffffffff80000000, 0xffffffff80000000, 0  );
-  TEST_N_VI_OP( 75, vnsra.wi, 0xffffffff40000000, 0xffffffff80000000, 1  );
-  TEST_N_VI_OP( 76, vnsra.wi, 0xffffffff01000000, 0xffffffff80000000, 7  );
-  TEST_N_VI_OP( 77, vnsra.wi, 0xffffffff00020000, 0xffffffff80000000, 14 );
+  TEST_N_VI_OP( 75, vnsra.wi, 0xffffffffc0000000, 0xffffffff80000000, 1  );
+  TEST_N_VI_OP( 76, vnsra.wi, 0xffffffffff000000, 0xffffffff80000000, 7  );
+  TEST_N_VI_OP( 77, vnsra.wi, 0xfffffffffffe0000, 0xffffffff80000000, 14 );
 	
   TEST_N_VI_OP( 78, vnsra.wi, 0x000000007fffffff, 0x000000007fffffff, 0  );
   TEST_N_VI_OP( 79, vnsra.wi, 0x000000003fffffff, 0x000000007fffffff, 1  );
@@ -138,9 +140,9 @@ RVTEST_VSET
   TEST_N_VI_OP( 81, vnsra.wi, 0x000000000001ffff, 0x000000007fffffff, 14 );
 	
   TEST_N_VI_OP( 82, vnsra.wi, 0xffffffff81818181, 0xffffffff81818181, 0  );
-  TEST_N_VI_OP( 83, vnsra.wi, 0xffffffff40c0c0c0, 0xffffffff81818181, 1  );
-  TEST_N_VI_OP( 84, vnsra.wi, 0xffffffff01030303, 0xffffffff81818181, 7  );
-  TEST_N_VI_OP( 85, vnsra.wi, 0xffffffff00020606, 0xffffffff81818181, 14 );	
+  TEST_N_VI_OP( 83, vnsra.wi, 0xffffffffc0c0c0c0, 0xffffffff81818181, 1  );
+  TEST_N_VI_OP( 84, vnsra.wi, 0xffffffffff030303, 0xffffffff81818181, 7  );
+  TEST_N_VI_OP( 85, vnsra.wi, 0xfffffffffffe0606, 0xffffffff81818181, 14 );	
 	
 #endif
 

--- a/isa/rv64uv/vsrl.S
+++ b/isa/rv64uv/vsrl.S
@@ -24,13 +24,13 @@ RVTEST_VSET
   TEST_VI_OP(n, vsrl.vi, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)	
 
 #define TEST_SRLWV(n, v, a) \
-  TEST_N_VV_OP(n, vnsrl.wv, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)
+  TEST_N_VV_OP(n, vnsrl.wv, ((v) >> (a)) & ((1 << (__riscv_vsew-1) << 1) - 1), v, a)
 
 #define TEST_SRLWX(n, v, a) \
-  TEST_N_VX_OP(n, vnsrl.wx, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)
+  TEST_N_VX_OP(n, vnsrl.wx, ((v) >> (a)) & ((1 << (__riscv_vsew-1) << 1) - 1), v, a)
 
 #define TEST_SRLWI(n, v, a) \
-  TEST_N_VI_OP(n, vnsrl.wi, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)	
+  TEST_N_VI_OP(n, vnsrl.wi, ((v) >> (a)) & ((1 << (__riscv_vsew-1) << 1) - 1), v, a)	
 
 	
   #-------------------------------------------------------------

--- a/isa/rv64uv/vsrl.S
+++ b/isa/rv64uv/vsrl.S
@@ -24,13 +24,13 @@ RVTEST_VSET
   TEST_VI_OP(n, vsrl.vi, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)	
 
 #define TEST_SRLWV(n, v, a) \
-  TEST_VV_OP(n, vnsrl.wv, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)
+  TEST_N_VV_OP(n, vnsrl.wv, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)
 
 #define TEST_SRLWX(n, v, a) \
-  TEST_VX_OP(n, vnsrl.wx, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)
+  TEST_N_VX_OP(n, vnsrl.wx, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)
 
 #define TEST_SRLWI(n, v, a) \
-  TEST_VI_OP(n, vnsrl.wi, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)	
+  TEST_N_VI_OP(n, vnsrl.wi, ((v) & ((1 << (__riscv_vsew-1) << 1) - 1)) >> (a), v, a)	
 
 	
   #-------------------------------------------------------------

--- a/isa/rv64uv/vwredsum.S
+++ b/isa/rv64uv/vwredsum.S
@@ -20,26 +20,26 @@ RVTEST_VSET
   # VX Tests
   #-------------------------------------------------------------
 
-  TEST_W_VV_OP_WITH_INIT( 2, vwredsum.vs, 0x00000000, 0x00000000, 0x00000000 );
-  TEST_W_VV_OP_WITH_INIT( 3, vwredsum.vs, 0x00000002, 0x00000001, 0x00000001 );
-  TEST_W_VV_OP_WITH_INIT( 4, vwredsum.vs, 0x0000000a, 0x00000003, 0x00000007 );
+  TEST_W_WV_RED_OP_WITH_INIT( 2, vwredsum.vs, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 3, vwredsum.vs, 0x00000002, 0x00000001, 0x00000001 );
+  TEST_W_WV_RED_OP_WITH_INIT( 4, vwredsum.vs, 0x0000000a, 0x00000003, 0x00000007 );
 
-  TEST_W_VV_OP_WITH_INIT( 5, vwredsum.vs, 0x00000000ffff8000, 0x00000000, 0xffff8000);
-  TEST_W_VV_OP_WITH_INIT( 6, vwredsum.vs, 0xffffffff80000000, 0x80000000, 0x00000000 );
-  TEST_W_VV_OP_WITH_INIT( 7, vwredsum.vs, 0x000000007fff8000, 0x80000000, 0xffffffffffff8000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 5, vwredsum.vs, 0x00000000ffff8000, 0x00000000, 0xffff8000);
+  TEST_W_WV_RED_OP_WITH_INIT( 6, vwredsum.vs, 0xffffffff80000000, 0x80000000, 0x00000000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 7, vwredsum.vs, 0xffffffff7fff8000, 0x80000000, 0xffffffffffff8000 );
 
-  TEST_W_VV_OP_WITH_INIT( 8, vwredsum.vs, 0x0000000000007fff, 0x00000000, 0x00007fff );
-  TEST_W_VV_OP_WITH_INIT( 9, vwredsum.vs, 0x000000007fffffff, 0x7fffffff, 0x00000000 );
-  TEST_W_VV_OP_WITH_INIT( 10, vwredsum.vs, 0x0000000080007ffe, 0x7fffffff, 0x00007fff );
+  TEST_W_WV_RED_OP_WITH_INIT( 8, vwredsum.vs, 0x0000000000007fff, 0x00000000, 0x00007fff );
+  TEST_W_WV_RED_OP_WITH_INIT( 9, vwredsum.vs, 0x000000007fffffff, 0x7fffffff, 0x00000000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 10, vwredsum.vs, 0x0000000080007ffe, 0x7fffffff, 0x00007fff );
 
-  TEST_W_VV_OP_WITH_INIT( 11, vwredsum.vs, 0xffffffff80007fff, 0x80000000, 0x00007fff );
-  TEST_W_VV_OP_WITH_INIT( 12, vwredsum.vs, 0x000000017fff7fff, 0x7fffffff, 0xffff8000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 11, vwredsum.vs, 0xffffffff80007fff, 0x80000000, 0x00007fff );
+  TEST_W_WV_RED_OP_WITH_INIT( 12, vwredsum.vs, 0x000000017fff7fff, 0x7fffffff, 0xffff8000 );
 
-  TEST_W_VV_OP_WITH_INIT( 13, vwredsum.vs, 0x00000000ffffffff, 0x00000000, 0xffffffff );
-  TEST_W_VV_OP_WITH_INIT( 14, vwredsum.vs, 0x0000000000000000, 0xffffffff, 0x00000001 );
-  TEST_W_VV_OP_WITH_INIT( 15, vwredsum.vs, 0x00000000fffffffe, 0xffffffff, 0xffffffff );
+  TEST_W_WV_RED_OP_WITH_INIT( 13, vwredsum.vs, 0x00000000ffffffff, 0x00000000, 0xffffffff );
+  TEST_W_WV_RED_OP_WITH_INIT( 14, vwredsum.vs, 0x0000000000000000, 0xffffffff, 0x00000001 );
+  TEST_W_WV_RED_OP_WITH_INIT( 15, vwredsum.vs, 0x00000000fffffffe, 0xffffffff, 0xffffffff );
 
-  TEST_W_VV_OP_WITH_INIT( 16, vwredsum.vs, 0x0000000080000000, 0x0000000000000001, 0x000000007fffffff );
+  TEST_W_WV_RED_OP_WITH_INIT( 16, vwredsum.vs, 0x0000000080000000, 0x0000000000000001, 0x000000007fffffff );
 	
   
 	

--- a/isa/rv64uv/vwredsumu.S
+++ b/isa/rv64uv/vwredsumu.S
@@ -20,26 +20,26 @@ RVTEST_VSET
   # VX Tests
   #-------------------------------------------------------------
 
-  TEST_W_VV_OP( 2, vwredsumu.vs, 0x00000000, 0x00000000, 0x00000000 );
-  TEST_W_VV_OP( 3, vwredsumu.vs, 0x00000002, 0x00000001, 0x00000001 );
-  TEST_W_VV_OP( 4, vwredsumu.vs, 0x0000000a, 0x00000003, 0x00000007 );
+  TEST_W_WV_RED_OP_WITH_INIT( 2, vwredsumu.vs, 0x00000000, 0x00000000, 0x00000000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 3, vwredsumu.vs, 0x00000002, 0x00000001, 0x00000001 );
+  TEST_W_WV_RED_OP_WITH_INIT( 4, vwredsumu.vs, 0x0000000a, 0x00000003, 0x00000007 );
 
-  TEST_W_VV_OP( 5, vwredsumu.vs, 0x00000000ffff8000, 0x00000000, 0xffff8000 );
-  TEST_W_VV_OP( 6, vwredsumu.vs, 0x0000000080000000, 0x80000000, 0x00000000 );
-  TEST_W_VV_OP( 7, vwredsumu.vs, 0x000000017fff8000, 0x80000000, 0xffff8000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 5, vwredsumu.vs, 0x00000000ffff8000, 0x00000000, 0xffff8000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 6, vwredsumu.vs, 0x0000000080000000, 0x80000000, 0x00000000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 7, vwredsumu.vs, 0x000000017fff8000, 0x80000000, 0xffff8000 );
 
-  TEST_W_VV_OP( 8, vwredsumu.vs, 0x0000000000007fff, 0x00000000, 0x00007fff );
-  TEST_W_VV_OP( 9, vwredsumu.vs, 0x000000007fffffff, 0x7fffffff, 0x00000000 );
-  TEST_W_VV_OP( 10, vwredsumu.vs, 0x0000000080007ffe, 0x7fffffff, 0x00007fff );
+  TEST_W_WV_RED_OP_WITH_INIT( 8, vwredsumu.vs, 0x0000000000007fff, 0x00000000, 0x00007fff );
+  TEST_W_WV_RED_OP_WITH_INIT( 9, vwredsumu.vs, 0x000000007fffffff, 0x7fffffff, 0x00000000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 10, vwredsumu.vs, 0x0000000080007ffe, 0x7fffffff, 0x00007fff );
 
-  TEST_W_VV_OP( 11, vwredsumu.vs, 0x0000000080007fff, 0x80000000, 0x0000000000007fff );
-  TEST_W_VV_OP( 12, vwredsumu.vs, 0x000000017fff7fff, 0x7fffffff, 0xffff8000 );
+  TEST_W_WV_RED_OP_WITH_INIT( 11, vwredsumu.vs, 0x0000000080007fff, 0x80000000, 0x0000000000007fff );
+  TEST_W_WV_RED_OP_WITH_INIT( 12, vwredsumu.vs, 0x000000017fff7fff, 0x7fffffff, 0xffff8000 );
 
-  TEST_W_VV_OP( 13, vwredsumu.vs, 0x00000000ffffffff, 0x00000000, 0xffffffff );
-  TEST_W_VV_OP( 14, vwredsumu.vs, 0x0000000100000000, 0xffffffff, 0x00000001 );
-  TEST_W_VV_OP( 15, vwredsumu.vs, 0x00000001fffffffe, 0xffffffff, 0xffffffff );
+  TEST_W_WV_RED_OP_WITH_INIT( 13, vwredsumu.vs, 0x00000000ffffffff, 0x00000000, 0xffffffff );
+  TEST_W_WV_RED_OP_WITH_INIT( 14, vwredsumu.vs, 0x0000000100000000, 0xffffffff, 0x00000001 );
+  TEST_W_WV_RED_OP_WITH_INIT( 15, vwredsumu.vs, 0x00000001fffffffe, 0xffffffff, 0xffffffff );
 
-  TEST_W_VV_OP( 16, vwredsumu.vs, 0x0000000080000000, 0x0000000000000001, 0x000000007fffffff );
+  TEST_W_WV_RED_OP_WITH_INIT( 16, vwredsumu.vs, 0x0000000080000000, 0x0000000000000001, 0x000000007fffffff );
 	
   
 	


### PR DESCRIPTION
## Overview

Over the past several months, we have been testing our new RISC-V vector unit extensively with this test suite
and also some other cases to verify the functionality of our design. The test suite provided by the RIOS lab is
the suite with the widest coverage we have seen so far and gave us enormous helps in discovering bugs in our design.
Despite this, this test suite is still far from comprehensive, and here are the issues that we have found.

## General Design Issue

### `vl` Coverage

So far, almost all of the tests we have used so far in this suite executes their instructions with very small `vl`.
This is useful to check whether the designer implement the instructions correctly for uncommon cases of short `vl`, 
which usually causes problem if they assume that vector operations often target long vectors of data. In our experience,
short vectors often cause data hazard if caution is not taken. However, this is not sufficient to expose bugs related 
to long vector data structure. Some common lengths that help expose problems include:

- For small `SEW`, make sure `vl` is at least great enough so that the vector is longer than `XLEN`. This is particularly true for any instructions that take in or output masks. 
- `LMUL != 1` cases are not checked at all. `LMUL < 1` is not likely to cause problem, but when `LMUL > 1` we have vectors
spanning across multiple register.
- Widening and narrowing instructions should check if `EMUL` is handled correctly, especially for widening instruction that
results in `EMUL > 1`.

In addition, `vsetvl` doesn't have its own test case, and this instruction and CSR states are complex enough to cause problem.

### Mask Coverage
Except for a few instructions that use masks as an input to the operation, none of the tests use masks to prevent the operation from being applied to elements. This also need to be tested, ideally along with instructions that depends on the output of masked instruction. Mask can often mess up the data hazard checking of output.

Mask generation, mask manipulation and permutation instructions have different behaviors with predication. Make sure that you also create test cases for these situation.

### Illegal Instruction and Overlapping Operands
The legality of an vector instructions depends on the `vconfig` CSR. If the destination register (group) overlap with any source (`rs1`, `rs2`, optionally `v0`) in a way not premitted by the specification, it is an illegal instruction. Scalar values in vector registers (as in reduction), mask register, and `v0` handling are some other corner cases that need to be tested. `vlxseg` will also fault if the index register overlap with any result registers (regardless of the location), so it should be tested separately. Even if they are not faulting, it is also important to check if overlapping is corrupting any data. 

If `LMUL > 1`, we have register groups that has to be aligned (`v2` is not a legal operand if `LMUL = 4`). This also need to be tested. In addition, if `vill` bit in the CSR is set, all vector instructions except for those doesn't depends on `vconfig` (like the whole-register operations) will fail. 

### `vstart`
This CSR has different effects on different instructions, and it's a good idea to test it on all instructions. Make sure to check if `vstart` is reset after execution, what happens when `vstart >= vl`, and so on. Anything smaller than `vstart` should not be touched for most instruction. Also, some instructions don't support nonzero `vstart` and are supposed to report an error, like `vcompress`. All of these instructions are either mask manipulation or permutation instructions. We didn't see any tests for this register in the test suite, so it should be worked on.

### Instructions That Depends on `VLMAX`
The test cases `vlre`, `vsre`, `vmre`, and `vrgather` need to take into account the register length on the processor. The first three are whole-register operations, and we need to make sure that the test vectors are long enough to verify if the vector length in the operation is correct. `vrgather` output zero when the index is greater than `VLMAX` (not `vl` as it is now in the tests), which should also be addressed. The standard offically supports at most `vlen=1024`, so you can pass that as the `AVL` to `vsetvl` and probe the vector length.

### Suggestion

Testing vector instruction requires great amount of test data, and it is very tedious to manually calculate and put them as a dataset into the test case. It will be a good idea to create a Python script to generate data randomly besides the edge cases that need to be tested manually. 

## Specific Instructions and Bug Fixed

Most bugs in the instructions are due to uninitialized vector registers. On Spike, all the tests will pass since spike initialized register to 0, but we often need to randomize the vector register contents to make sure that the instructions is not modifying the tail or inactive elements. The buggy tests did not clear the unused tail bits, causing them to fail. I opened a PR along with this report to presents my fixes, but please note that they only make sure that the tests will pass with randomized register initialization, and it is important to verify the instructions is not corrupting data outside of active region. I recommend creating a script to generate random data initial value for vector register so that the tests will work on Spike.

There are also some bugs in the test for instructions that have different `EEW` on `vd`. The `vmv` instructions for checking the result is executed with the wrong `SEW`, and some changes in the PR address that.

We are also seeing problems in the expected value in `vnsra` and `vwredsum` tests, mostly due to wrong bit width when calculating the tests. 

The PR doesn't include every bugs that we have found. As mentioned earlier, the suite is not implementing `VLMAX`-dependent tests correctly, and that needs to be fixed with a script generating test code. In addition, `vsexeg` test has a few cases that will write to the memory locations where array indices for later cases are stored, and because it is using the same index register for both read and write (store will not affect register value), the tests can still pass unless the data being written to the index location will be interpreted as unaligned memory location. This also need to be fixed. 

We haven't have time to run benchmark tests for this suite, but hopefully these feedback can help your team start addressing the problem in the ISA tests. Please let me know if you have any questions. 